### PR TITLE
Making compatible with API 11

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "21.1.2"
 
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 11
         targetSdkVersion 19
         versionName project.VERSION_NAME
         versionCode Integer.parseInt(project.VERSION_CODE)

--- a/library/src/main/java/com/getbase/floatingactionbutton/FloatingActionsMenu.java
+++ b/library/src/main/java/com/getbase/floatingactionbutton/FloatingActionsMenu.java
@@ -399,22 +399,22 @@ public class FloatingActionsMenu extends ViewGroup {
       mCollapseDir.setInterpolator(sCollapseInterpolator);
       mCollapseAlpha.setInterpolator(sCollapseInterpolator);
 
-      mCollapseAlpha.setProperty(View.ALPHA);
+      mCollapseAlpha.setPropertyName("alpha");
       mCollapseAlpha.setFloatValues(1f, 0f);
 
-      mExpandAlpha.setProperty(View.ALPHA);
+      mExpandAlpha.setPropertyName("alpha");
       mExpandAlpha.setFloatValues(0f, 1f);
 
       switch (mExpandDirection) {
       case EXPAND_UP:
       case EXPAND_DOWN:
-        mCollapseDir.setProperty(View.TRANSLATION_Y);
-        mExpandDir.setProperty(View.TRANSLATION_Y);
+        mCollapseDir.setPropertyName("translationY");
+        mExpandDir.setPropertyName("translationY");
         break;
       case EXPAND_LEFT:
       case EXPAND_RIGHT:
-        mCollapseDir.setProperty(View.TRANSLATION_X);
-        mExpandDir.setProperty(View.TRANSLATION_X);
+        mCollapseDir.setPropertyName("translationX");
+        mExpandDir.setPropertyName("translationX");
         break;
       }
     }


### PR DESCRIPTION
ObjectAnimator.setProperty() only accessible from API 14. I changed it to setPropertyName with the equivalent tags. Now every variable and call is working on API 11.