### PR TITLE
enable fab in edit mode

### DIFF
--- a/library/src/main/java/com/getbase/floatingactionbutton/FloatingActionButton.java
+++ b/library/src/main/java/com/getbase/floatingactionbutton/FloatingActionButton.java
@@ -72,6 +72,10 @@ public class FloatingActionButton extends ImageButton {
   }
 
   void init(Context context, AttributeSet attributeSet) {
+    if (isInEditMode()) {
+      return;
+    }
+    
     TypedArray attr = context.obtainStyledAttributes(attributeSet, R.styleable.FloatingActionButton, 0, 0);
     mColorNormal = attr.getColor(R.styleable.FloatingActionButton_fab_colorNormal, getColor(android.R.color.holo_blue_dark));
     mColorPressed = attr.getColor(R.styleable.FloatingActionButton_fab_colorPressed, getColor(android.R.color.holo_blue_light));


### PR DESCRIPTION
sorry for my poor English.
I'm developing an app that using this fab library, and I made an activity layout xml file contains fab view. when i want to preview the result in edit mode, the android studio notice that fab view dont support. so I fix this bug and create a pull request