### PR TITLE
Issue-180: overload method collapse with immediate parameter

### DIFF
--- a/library/src/main/java/com/getbase/floatingactionbutton/FloatingActionsMenu.java
+++ b/library/src/main/java/com/getbase/floatingactionbutton/FloatingActionsMenu.java
@@ -510,12 +510,16 @@ public class FloatingActionsMenu extends ViewGroup {
   }
 
   public void collapse() {
+    collapse(false);
+  }
+
+  public void collapse(boolean immediately) {
     if (mExpanded) {
       mExpanded = false;
       mTouchDelegateGroup.setEnabled(false);
-      mCollapseAnimation.start();
       mExpandAnimation.cancel();
-
+      mCollapseAnimation.setDuration(immediately ? 0 : ANIMATION_DURATION);
+      mCollapseAnimation.start();
       if (mListener != null) {
         mListener.onMenuCollapsed();
       }


### PR DESCRIPTION
An attempt to fix issue #180 with setting collapse animation duration to 0 if immediate parameter is true and default value otherwise.