### PR TITLE
Use setLayerType for animations

### DIFF
--- a/library/src/main/java/com/getbase/floatingactionbutton/FloatingActionsMenu.java
+++ b/library/src/main/java/com/getbase/floatingactionbutton/FloatingActionsMenu.java
@@ -1,5 +1,7 @@
 package com.getbase.floatingactionbutton;
 
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
 import android.animation.AnimatorSet;
 import android.animation.ObjectAnimator;
 import android.content.Context;
@@ -469,12 +471,29 @@ public class FloatingActionsMenu extends ViewGroup {
 
       // Now that the animations have targets, set them to be played
       if (!animationsSetToPlay) {
+        addLayerTypeListener(mExpandDir, view);
+        addLayerTypeListener(mCollapseDir, view);
+
         mCollapseAnimation.play(mCollapseAlpha);
         mCollapseAnimation.play(mCollapseDir);
         mExpandAnimation.play(mExpandAlpha);
         mExpandAnimation.play(mExpandDir);
         animationsSetToPlay = true;
       }
+    }
+
+    private void addLayerTypeListener(Animator animator, final View view) {
+      animator.addListener(new AnimatorListenerAdapter() {
+        @Override
+        public void onAnimationEnd(Animator animation) {
+          view.setLayerType(LAYER_TYPE_NONE, null);
+        }
+
+        @Override
+        public void onAnimationStart(Animator animation) {
+          view.setLayerType(LAYER_TYPE_HARDWARE, null);
+        }
+      });
     }
   }
 


### PR DESCRIPTION
This helps animations run smoothly since there's a lot going on.

The internal mechanics of `setLayerType` means that this renders each button using the GPU and then animates the rendered version of the view. The buttons don't need to be laid out during the animation, so this works well.